### PR TITLE
Add ES11 BigInt conversion functions

### DIFF
--- a/pjcl-documentation.tex
+++ b/pjcl-documentation.tex
@@ -468,7 +468,7 @@ The function returns a returns a big integer with mathematical value $x$.
 \subsection{\tt export function pjclES11BI2BigInt(x)}
 
 The parameter {\tt x} is expected to be a big integer with mathematical value $x$.
-The function returns an ECMAScript 202 (ES11) BigInt with mathematical value $x$.
+The function returns an ECMAScript 2020 (ES11) BigInt with mathematical value $x$.
 
 \subsection{\tt export function pjclBigInt2ByteArray(x)\\export function pjclBigInt2ByteArray(x,minByteLength)}
 

--- a/pjcl-documentation.tex
+++ b/pjcl-documentation.tex
@@ -459,6 +459,17 @@ n < 2^{32}$.  The function returns a byte array obtained by mapping
 each $n$ to four bytes and pushing
 the bytes to the array, most significant byte frst.
 
+\subsection{\tt export function pjclBigInt2ES11BI(x)}
+
+The parameter {\tt x} is expected to be an ECMAScript 2020 (ES11) BigInt with
+mathematical value $x$.
+The function returns a returns a big integer with mathematical value $x$.
+
+\subsection{\tt export function pjclES11BI2BigInt(x)}
+
+The parameter {\tt x} is expected to be a big integer with mathematical value $x$.
+The function returns an ECMAScript 202 (ES11) BigInt with mathematical value $x$.
+
 \subsection{\tt export function pjclBigInt2ByteArray(x)\\export function pjclBigInt2ByteArray(x,minByteLength)}
 
 The parameter {\tt x} is expected to be a big integer with mathematical value $x$,

--- a/pjcl-with-argument-checking.js
+++ b/pjcl-with-argument-checking.js
@@ -249,6 +249,32 @@ export function pjclUI32Array2ByteArray(x) {
     return byteArray;
 }
 
+export function pjclBigInt2ES11BI(x) {
+    if (!pjclWellFormed(x)) {throw new Error("x not well formed in pjclBigInt2ES11BI");}
+    const _pjclBaseBitLength = BigInt(pjclBaseBitLength);
+    var y = BigInt(0);
+    for (var i = x.length - 1; i >= 0; i--) {
+        y = (y << _pjclBaseBitLength) | BigInt(x[i]);
+    }
+    if (x.negative)
+        return -y;
+    return y;
+}
+
+export function pjclES11BI2BigInt(x) {
+    if (typeof x !== "bigint") {throw new Error("x not an ES11 BigInt in pjclES11BI2BigInt");}
+    const _pjclBaseBitLength = BigInt(pjclBaseBitLength), _pjclBaseMask = BigInt(pjclBaseMask);
+    var y = [];
+    if (i < 0) {
+        y.negative = true;
+        x = -x;
+    }
+    for(; y; y >>= _pjclBaseBitLength) {
+        y.push(Number(x & _pjclBaseMask));
+    }
+    return y;
+}
+
 export function pjclBigInt2ByteArray(x,minByteLength) {
     if (minByteLength === undefined) {
         minByteLength = 0;

--- a/pjcl-with-argument-checking.js
+++ b/pjcl-with-argument-checking.js
@@ -251,10 +251,10 @@ export function pjclUI32Array2ByteArray(x) {
 
 export function pjclBigInt2ES11BI(x) {
     if (!pjclWellFormed(x)) {throw new Error("x not well formed in pjclBigInt2ES11BI");}
-    const _pjclBaseBitLength = BigInt(pjclBaseBitLength);
+    const pjclBaseBitLength = BigInt(this.pjclBaseBitLength);
     var y = BigInt(0);
     for (var i = x.length - 1; i >= 0; i--) {
-        y = (y << _pjclBaseBitLength) | BigInt(x[i]);
+        y = (y << pjclBaseBitLength) | BigInt(x[i]);
     }
     if (x.negative)
         return -y;
@@ -263,14 +263,14 @@ export function pjclBigInt2ES11BI(x) {
 
 export function pjclES11BI2BigInt(x) {
     if (typeof x !== "bigint") {throw new Error("x not an ES11 BigInt in pjclES11BI2BigInt");}
-    const _pjclBaseBitLength = BigInt(pjclBaseBitLength), _pjclBaseMask = BigInt(pjclBaseMask);
+    const pjclBaseBitLength = BigInt(this.pjclBaseBitLength), pjclBaseMask = BigInt(this.pjclBaseMask);
     var y = [];
     if (i < 0) {
         y.negative = true;
         x = -x;
     }
-    for(; y; y >>= _pjclBaseBitLength) {
-        y.push(Number(x & _pjclBaseMask));
+    for(; y; y >>= pjclBaseBitLength) {
+        y.push(Number(x & pjclBaseMask));
     }
     return y;
 }

--- a/pjcl.js
+++ b/pjcl.js
@@ -160,10 +160,10 @@ export function pjclUI32Array2ByteArray(x) {
 }
 
 export function pjclBigInt2ES11BI(x) {
-    const _pjclBaseBitLength = BigInt(pjclBaseBitLength);
+    const pjclBaseBitLength = BigInt(this.pjclBaseBitLength);
     var y = BigInt(0);
     for (var i = x.length - 1; i >= 0; i--) {
-        y = (y << _pjclBaseBitLength) | BigInt(x[i]);
+        y = (y << pjclBaseBitLength) | BigInt(x[i]);
     }
     if (x.negative) 
         return -y;
@@ -171,14 +171,14 @@ export function pjclBigInt2ES11BI(x) {
 }
 
 export function pjclES11BI2BigInt(x) {
-    const _pjclBaseBitLength = BigInt(pjclBaseBitLength), _pjclBaseMask = BigInt(pjclBaseMask);
+    const pjclBaseBitLength = BigInt(this.pjclBaseBitLength), pjclBaseMask = BigInt(this.pjclBaseMask);
     var y = [];
     if (i < 0) {
         y.negative = true;
         x = -x;
     }
-    for(; y; y >>= _pjclBaseBitLength) {
-        y.push(Number(x & _pjclBaseMask));
+    for(; y; y >>= pjclBaseBitLength) {
+        y.push(Number(x & pjclBaseMask));
     }
     return y;
 }

--- a/pjcl.js
+++ b/pjcl.js
@@ -159,6 +159,30 @@ export function pjclUI32Array2ByteArray(x) {
     return byteArray;
 }
 
+export function pjclBigInt2ES11BI(x) {
+    const _pjclBaseBitLength = BigInt(pjclBaseBitLength);
+    var y = BigInt(0);
+    for (var i = x.length - 1; i >= 0; i--) {
+        y = (y << _pjclBaseBitLength) | BigInt(x[i]);
+    }
+    if (x.negative) 
+        return -y;
+    return y;
+}
+
+export function pjclES11BI2BigInt(x) {
+    const _pjclBaseBitLength = BigInt(pjclBaseBitLength), _pjclBaseMask = BigInt(pjclBaseMask);
+    var y = [];
+    if (i < 0) {
+        y.negative = true;
+        x = -x;
+    }
+    for(; y; y >>= _pjclBaseBitLength) {
+        y.push(Number(x & _pjclBaseMask));
+    }
+    return y;
+}
+
 export function pjclBigInt2ByteArray(x,minByteLength) {
     if (minByteLength === undefined) {
         minByteLength = 0;


### PR DESCRIPTION
I tried to match the coding style and function naming conventions of the existing codebase in this commit. I believe I did _not_ damage the ability of the script to compile and run on older ECMAScript engines; I think it _should_ even be compatible with BigInt polyfills on such platforms.

The PDF will have to be updated — I'm not familiar with LaTeX; I just winged the changes in a text editor.

-----

(Fixes #2)