### PR TITLE
Add ES11 BigInt conversion functions

### DIFF
--- a/pjcl-documentation.tex
+++ b/pjcl-documentation.tex
@@ -327,11 +327,11 @@ integer, or {\tt false} otherwise.  It is used for argument checking.
 
 \section{Conversion functions}
 
-\subsection{\tt export function pjclBigInt_from_ES11BigInt(x)}
+\subsection{\tt export function pjclBigInt_from_ES11BigInt(i)}
 
 The parameter {\tt x} is expected to be an ECMAScript 2020 (ES11) BigInt with
-mathematical value $x$.
-The function returns a returns a big integer with mathematical value $x$.
+mathematical value $i$.
+The function returns a returns a big integer with mathematical value $i$.
 
 \subsection{\tt export function pjclBigInt_to_ES11BigInt(x)}
 

--- a/pjcl-documentation.tex
+++ b/pjcl-documentation.tex
@@ -327,6 +327,17 @@ integer, or {\tt false} otherwise.  It is used for argument checking.
 
 \section{Conversion functions}
 
+\subsection{\tt export function pjclBigInt_from_ES11BigInt(x)}
+
+The parameter {\tt x} is expected to be an ECMAScript 2020 (ES11) BigInt with
+mathematical value $x$.
+The function returns a returns a big integer with mathematical value $x$.
+
+\subsection{\tt export function pjclBigInt_to_ES11BigInt(x)}
+
+The parameter {\tt x} is expected to be a big integer with mathematical value $x$.
+The function returns an ECMAScript 2020 (ES11) BigInt with mathematical value $x$.
+
 \subsection{\tt export function pjclByte2BitArray(byte)}
 
 The parameter {\tt byte} is expected to be a JavaScript floating point

--- a/pjcl-with-argument-checking.js
+++ b/pjcl-with-argument-checking.js
@@ -69,6 +69,37 @@ function pjclIsPoint(P) {
 }
 // end arg checking
 
+export function pjclBigInt_from_ES11BigInt(i) {
+    // begin arg checking
+    if (typeof x !== "bigint") {throw new Error("i not an ES11 BigInt in pjclBigInt_from_ES11BigInt");}
+    // end arg checking
+    const _pjclBaseBitLength = BigInt(pjclBaseBitLength),
+          _pjclBaseMask = BigInt(pjclBaseMask);
+    var x = [];
+    if (i < 0) {
+        x.negative = true;
+        i = -i;
+    }
+    while (i) {
+        x.push(Number(i & _pjclBaseMask)));
+        i >>= _pjclBaseBitLength;
+    }
+    return x;
+}
+
+export function pjclBigInt_to_ES11BigInt(x) {
+    // begin arg checking
+    if (!pjclWellFormed(x)) {throw new Error("x not well formed in pjclBigInt_to_ES11BigInt");}
+    // end arg checking
+    const _pjclBaseBitLength = BigInt(pjclBaseBitLength);
+    var i = x.reduceRight((i, nextLeg) => (
+        (i << _pjclBaseBitLength) | BigInt(nextLeg)
+    ), BigInt(0));
+    if (x.negative)
+        return -i;
+    return i;
+}
+
 export function pjclByte2BitArray(byte) {
     return [(byte >>> 7) & 1, (byte >>> 6) & 1, (byte >>> 5) & 1, (byte >>> 4) & 1, (byte >>> 3) & 1, (byte >>> 2) & 1, (byte >>> 1) & 1, byte & 1];
 }

--- a/pjcl-with-argument-checking.js
+++ b/pjcl-with-argument-checking.js
@@ -81,7 +81,7 @@ export function pjclBigInt_from_ES11BigInt(i) {
         i = -i;
     }
     while (i) {
-        x.push(Number(i & _pjclBaseMask)));
+        x.push(Number(i & _pjclBaseMask));
         i >>= _pjclBaseBitLength;
     }
     return x;

--- a/pjcl.js
+++ b/pjcl.js
@@ -6,6 +6,31 @@ export const pjclBaseInv = 1 / pjclBase;
 export const pjclBaseAsBigInt = [0,1];
 export const pjclHalfBase = 1 << (pjclBaseBitLength - 1);
 
+export function pjclBigInt_from_ES11BigInt(i) {
+    const _pjclBaseBitLength = BigInt(pjclBaseBitLength),
+          _pjclBaseMask = BigInt(pjclBaseMask);
+    var x = [];
+    if (i < 0) {
+        x.negative = true;
+        i = -i;
+    }
+    while (i) {
+        x.push(Number(i & _pjclBaseMask));
+        i >>= _pjclBaseBitLength;
+    }
+    return x;
+}
+
+export function pjclBigInt_to_ES11BigInt(x) {
+    const _pjclBaseBitLength = BigInt(pjclBaseBitLength);
+    var i = x.reduceRight((i, nextLeg) => (
+        (i << _pjclBaseBitLength) | BigInt(nextLeg)
+    ), BigInt(0));
+    if (x.negative)
+        return -i;
+    return i;
+}
+
 export function pjclByte2BitArray(byte) {
     return [(byte >>> 7) & 1, (byte >>> 6) & 1, (byte >>> 5) & 1, (byte >>> 4) & 1, (byte >>> 3) & 1, (byte >>> 2) & 1, (byte >>> 1) & 1, byte & 1];
 }


### PR DESCRIPTION
- Changes from previous PR incorporated

   * Remove `this` keyword
   * function names use `_to_` and `_from_` for readability

- Used native `array.reduceRight` instead of a decrementing `for`-loop in the to-native function.

- Used a `while` loop, slightly less convoluted than the previous `for`-loop in the from-native function.